### PR TITLE
Harden key copy flow and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gocache/
+.gomodcache/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 ```bash
 go mod tidy
+go test ./...
 go build -o ssh-copy-id.exe main.go
 ```
 
@@ -88,6 +89,8 @@ ssh-keygen -t ed25519 -C "your_email@example.com"
 3. **密钥格式**: 确保你的公钥文件格式正确（通常以ssh-rsa、ssh-ed25519等开头）。
 
 4. **权限**: 程序会自动设置远程服务器上.ssh目录和authorized_keys文件的正确权限。
+
+5. **输入校验**: 程序会在复制前校验公钥格式，尽早暴露错误输入。
 
 ## 依赖
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -15,12 +14,10 @@ import (
 const version = "1.1.0"
 
 type Config struct {
-	Host       string
-	Port       string
-	User       string
-	KeyPath    string
-	Password   string
-	PrivateKey string
+	Host    string
+	Port    string
+	User    string
+	KeyPath string
 }
 
 func main() {
@@ -64,12 +61,15 @@ func printUsage() {
 }
 
 func parseArgs() *Config {
+	return parseArgsFrom(os.Args[1:], os.Getenv, getDefaultKeyPath)
+}
+
+func parseArgsFrom(args []string, lookupEnv func(string) string, defaultKeyPath func() string) *Config {
 	config := &Config{
 		Port:    "22",
-		KeyPath: getDefaultKeyPath(),
+		KeyPath: defaultKeyPath(),
 	}
 
-	args := os.Args[1:]
 	i := 0
 
 	for i < len(args) {
@@ -97,7 +97,7 @@ func parseArgs() *Config {
 					config.Host = parts[1]
 				} else {
 					config.Host = parts[0]
-					config.User = os.Getenv("USERNAME")
+					config.User = lookupEnv("USERNAME")
 				}
 				i++
 			} else {
@@ -154,7 +154,7 @@ func readPublicKey(keyPath string) (string, error) {
 		keyPath = filepath.Join(homeDir, keyPath[2:])
 	}
 
-	content, err := ioutil.ReadFile(keyPath)
+	content, err := os.ReadFile(keyPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read key file %s: %v", keyPath, err)
 	}
@@ -162,6 +162,10 @@ func readPublicKey(keyPath string) (string, error) {
 	publicKey := strings.TrimSpace(string(content))
 	if publicKey == "" {
 		return "", fmt.Errorf("key file is empty")
+	}
+
+	if _, _, _, _, err := ssh.ParseAuthorizedKey(content); err != nil {
+		return "", fmt.Errorf("invalid public key format: %v", err)
 	}
 
 	return publicKey, nil
@@ -196,15 +200,8 @@ func copySSHKey(config *Config, publicKey string) error {
 	}
 	defer session.Close()
 
-	commands := []string{
-		"mkdir -p ~/.ssh",
-		"chmod 700 ~/.ssh",
-		fmt.Sprintf("echo '%s' >> ~/.ssh/authorized_keys", publicKey),
-		"chmod 600 ~/.ssh/authorized_keys",
-		"sort ~/.ssh/authorized_keys | uniq > ~/.ssh/authorized_keys.tmp && mv ~/.ssh/authorized_keys.tmp ~/.ssh/authorized_keys",
-	}
-
-	command := strings.Join(commands, " && ")
+	command := buildAuthorizedKeysCommand()
+	session.Stdin = strings.NewReader(publicKey + "\n")
 
 	output, err := session.CombinedOutput(command)
 	if err != nil {
@@ -221,4 +218,18 @@ func readPassword() (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(password), nil
+}
+
+func buildAuthorizedKeysCommand() string {
+	commands := []string{
+		"umask 077",
+		"mkdir -p ~/.ssh",
+		"touch ~/.ssh/authorized_keys",
+		"cat >> ~/.ssh/authorized_keys",
+		"sort -u ~/.ssh/authorized_keys -o ~/.ssh/authorized_keys",
+		"chmod 700 ~/.ssh",
+		"chmod 600 ~/.ssh/authorized_keys",
+	}
+
+	return strings.Join(commands, " && ")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseArgsFromSupportsHyphenatedHost(t *testing.T) {
+	config := parseArgsFrom(
+		[]string{"user@dev-box.internal"},
+		func(string) string { return "ignored" },
+		func() string { return "default.pub" },
+	)
+
+	if config.User != "user" {
+		t.Fatalf("expected user %q, got %q", "user", config.User)
+	}
+	if config.Host != "dev-box.internal" {
+		t.Fatalf("expected host %q, got %q", "dev-box.internal", config.Host)
+	}
+	if config.Port != "22" {
+		t.Fatalf("expected default port %q, got %q", "22", config.Port)
+	}
+	if config.KeyPath != "default.pub" {
+		t.Fatalf("expected default key path %q, got %q", "default.pub", config.KeyPath)
+	}
+}
+
+func TestParseArgsFromUsesCurrentUserWhenMissing(t *testing.T) {
+	config := parseArgsFrom(
+		[]string{"-p", "2222", "server.example.com"},
+		func(key string) string {
+			if key == "USERNAME" {
+				return "current-user"
+			}
+			return ""
+		},
+		func() string { return "default.pub" },
+	)
+
+	if config.User != "current-user" {
+		t.Fatalf("expected fallback user %q, got %q", "current-user", config.User)
+	}
+	if config.Host != "server.example.com" {
+		t.Fatalf("expected host %q, got %q", "server.example.com", config.Host)
+	}
+	if config.Port != "2222" {
+		t.Fatalf("expected port %q, got %q", "2222", config.Port)
+	}
+}
+
+func TestBuildAuthorizedKeysCommand(t *testing.T) {
+	command := buildAuthorizedKeysCommand()
+
+	expectedParts := []string{
+		"umask 077",
+		"mkdir -p ~/.ssh",
+		"touch ~/.ssh/authorized_keys",
+		"cat >> ~/.ssh/authorized_keys",
+		"sort -u ~/.ssh/authorized_keys -o ~/.ssh/authorized_keys",
+		"chmod 700 ~/.ssh",
+		"chmod 600 ~/.ssh/authorized_keys",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(command, part) {
+			t.Fatalf("expected command to contain %q, got %q", part, command)
+		}
+	}
+
+	if strings.Contains(command, "echo '") {
+		t.Fatalf("command should not inline the public key: %q", command)
+	}
+}


### PR DESCRIPTION
## Summary
- validate the public key before attempting the SSH copy flow
- stop inlining the public key into the remote shell command and stream it over stdin instead
- add unit tests for argument parsing and authorized_keys command construction
- ignore local Go build caches and document `go test ./...`

## Verification
- go test ./...
- go build ./...
- go vet ./...